### PR TITLE
Add required elasticache:DescribeCacheSubnetGroups permission for Scout2

### DIFF
--- a/IAM-Policies/Scout2-Default.json
+++ b/IAM-Policies/Scout2-Default.json
@@ -24,6 +24,7 @@
                 "ec2:DescribeSubnets",
                 "ec2:DescribeVpcs",
                 "elasticache:DescribeCacheClusters",
+                "elasticache:DescribeCacheSubnetGroups",
                 "elasticloadbalancing:DescribeLoadBalancers",
                 "elasticmapreduce:DescribeCluster",
                 "elasticmapreduce:ListClusters",


### PR DESCRIPTION
Without this permission Scout2 generates an error.