### PR TITLE
Add some missing permissions

### DIFF
--- a/IAM-Policies/Scout2-Default.json
+++ b/IAM-Policies/Scout2-Default.json
@@ -33,6 +33,8 @@
                 "elasticloadbalancing:DescribeLoadBalancerAttributes",
                 "elasticloadbalancing:DescribeLoadBalancers",
                 "elasticloadbalancing:DescribeSSLPolicies",
+                "elasticloadbalancing:DescribeListeners",
+                "elasticloadbalancing:DescribeLoadBalancerPolicies",
                 "elasticmapreduce:DescribeCluster",
                 "elasticmapreduce:ListClusters",
                 "iam:GenerateCredentialReport",


### PR DESCRIPTION
We noticed that there were a couple of permissions required when running Scout2 that the default IAM policy didn't include, so have included them here.